### PR TITLE
Correções no botão gravar e gravar edição. Adicionado paginação ao formulario de fabricantes

### DIFF
--- a/JLoja /WebContent /view /fabricante.xhtml
+++ b/JLoja /WebContent /view /fabricante.xhtml
@@ -10,22 +10,22 @@ xmlns:ui="http://java.sun.com/jsf/facelets">
     <ui:composition template="/ModeloJloja/modeloJLoja.xhtml">
     <ui:define name="modeloJLoja">
     
-        <h:form id="form">
+        <h:form id="form" >
            <f:event listener="#{fabricanteMB.listarFabricante}"
            type="preRenderView"></f:event> 
               <p:dataTable id="fabricante" var="fab" 
               filteredValue="#{fabricanteMB.listaFabricantesFiltrados}"
-              value="#{fabricanteMB.listaFabricantes}">
+              value="#{fabricanteMB.listaFabricantes}" rowsPerPageTemplate="5,10,15" paginator="true" rows="5">
               <f:facet name="header">
               Fabricantes
           </f:facet>
-               <p:column headerText="Código" filterBy="#{fab.idfabricante}">
+               <p:column headerText="CÃ³digo" filterBy="#{fab.idfabricante}">
                        <h:outputText value="#{fab.idfabricante}" />
                </p:column>
                <p:column headerText="Nome" filterBy="#{fab.descricao}">
-                     <h:outputText value="#{fab.descricao}" />
+                    	<h:outputText value="#{fab.descricao}" />
                </p:column>
-               <p:column headerText="Ação" style="width:10%;text-align: center">
+               <p:column headerText="AÃ§Ã£o" style="width:10%;text-align: center">
                   <p:commandButton icon="ui-pi-user-edit" title="Alterar"
                   onclick="PF('dlgEdi').show();"
                   actionListener="#{fabricanteMB.buscarFabricanteCodigo(fab.idfabricante)}"
@@ -38,9 +38,9 @@ xmlns:ui="http://java.sun.com/jsf/facelets">
                    <p:overlayPanel id="excPanel" for="btnExc" hideEffect="fade">
                    <p:commandButton value="Sim" icon="ui-icon-check" 
                   actionListener="#{fabricanteMB.excluirFabricante}"
-                  update=":form:fabricante :growl"/>
+                  update=":form:fabricante :fabCadastro:pnlCadastro :growl"/>
   
-                   <p:commandButton value="Não" icon="ui-icon-close" 
+                   <p:commandButton value="NÃ£o" icon="ui-icon-close" 
                    update=":form:fabricante" />
                    </p:overlayPanel>
                    </p:column>
@@ -51,34 +51,34 @@ xmlns:ui="http://java.sun.com/jsf/facelets">
                    </f:facet> 
            </p:dataTable>
         </h:form>
-         
+        
        <p:dialog widgetVar="dlgCad" id="cadfab" header="Cadastro de Fabricante" 
        modal="true" appendTo="@(body)" resizable="false" draggable="false"
        width="30%"> 
-       <h:form id="fabCadastro">
-       <h:panelGrid id="pnlCadastro" columns="2" cellpadding="5"
+       	<h:form id="fabCadastro">
+       	<h:panelGrid id="pnlCadastro" columns="2" cellpadding="5"
        width="100%">
-       <h:outputLabel value="Código:" />
-       <p:inputText disabled="true" id="id" value="" style="width:30%;" />
-       <h:outputLabel value="Nome:" />
-       <p:inputText id="desc" value="#{fabricanteMB.fabricanteEntity.descricao}"
-        required="true" style="width:100%;">
-       </p:inputText>
-       <f:facet name="footer">
-       <p:commandButton value="Gravar"
-              actionListener="#{fabricanteMB.adicionarFabricante}"
-              icon="ui-icon-disk" update=":form:fabricante :fabCadastro:pnlCadastro :growl" />
-       </f:facet>
-       </h:panelGrid>
-       </h:form>
+       		<h:outputLabel value="CÃ³digo:" />
+       		<p:inputText disabled="true" id="id" value="" style="width:30%;" />
+       		<h:outputLabel value="Nome:" />
+      		 <p:inputText id="desc" value="#{fabricanteMB.fabricanteEntity.descricao}"
+       		required="true" style="width:100%;">
+       		</p:inputText>
+       		<f:facet name="footer">
+       		<p:commandButton value="Gravar"
+              	actionListener="#{fabricanteMB.adicionarFabricante}"
+              	icon="ui-icon-disk" update=":form:fabricante :fabCadastro:pnlCadastro :growl" />
+       		</f:facet>
+      	</h:panelGrid>
+       	</h:form>
        </p:dialog>
        
        <p:dialog widgetVar="dlgEdi" id="edifab" 
-       header="Edição de Fabricante" modal="true" appendTo="@(body)" 
+       header="EdiÃ§Ã£o de Fabricante" modal="true" appendTo="@(body)" 
        resizable="false" draggable="false" width="30%"> 
        <h:form id="fabEditar">
        <h:panelGrid id="pnlEditar" columns="2" cellpadding="5" width="100%">
-       <h:outputLabel value="Código:" />
+       <h:outputLabel value="CÃ³digo:" />
        <p:inputText disabled="true" id="id" value="#{fabricanteMB.fabricanteEntity.idfabricante}"
         style="width:30%;" />
        <h:outputLabel value="Nome:" />
@@ -87,7 +87,7 @@ xmlns:ui="http://java.sun.com/jsf/facelets">
        style="width:100%;">
        </p:inputText>
        <f:facet name="footer">
-       <p:commandButton value="Gravar edição"
+       <p:commandButton value="Gravar ediÃ§Ã£o"
               actionListener="#{fabricanteMB.editarFabricante}"
               onclick="PF('dlgEdi').hide();" icon="ui-icon-disk"
               update=":form:fabricante :fabCadastro:pnlCadastro :growl" />


### PR DESCRIPTION
Correção que limpava o retorno de fabricantes da tabela ao pressionar o botão "gravar" e "gravar edição" ao adicionar e editar um fabricante.
Adicionado a paginação na tabela de fabricantes para melhor visualização de no máximo 5 fabricantes por paginas.